### PR TITLE
表示されない画像とプレースホルダーの修正

### DIFF
--- a/eating-log.html
+++ b/eating-log.html
@@ -81,7 +81,7 @@
 
             <div class="col-md-4">
                 <div class="log-card">
-                    <img src="https://images.unsplash.com/photo-1550966871-3ed3c47e2ce2?auto=format&fit=crop&w=600&q=80" class="log-img" alt="Sushi">
+                    <img src="https://images.unsplash.com/photo-1579027989536-b7b1f875659b?auto=format&fit=crop&w=600&q=80" class="log-img" alt="Sushi">
                     <div class="p-3">
                         <div class="d-flex justify-content-between align-items-center mb-2">
                             <small class="text-muted">2023.12.25</small>

--- a/gourmet-guide.html
+++ b/gourmet-guide.html
@@ -49,7 +49,7 @@
                     <!-- 記事1 -->
                     <div class="col-md-6">
                         <div class="article-card">
-                            <img src="https://images.unsplash.com/photo-1550966871-3ed3c47e2ce2?auto=format&fit=crop&w=600&q=80" class="card-img-top article-img" alt="ワイン">
+                            <img src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=600&q=80" class="card-img-top article-img" alt="ワイン">
                             <div class="card-body">
                                 <span class="badge bg-secondary mb-2">知識</span>
                                 <h5 class="card-title fw-bold">初心者でもわかる！ワインの選び方</h5>

--- a/shop-detail.html
+++ b/shop-detail.html
@@ -135,7 +135,7 @@
                     
                     <div class="review-card">
                         <div class="d-flex align-items-center mb-2">
-                            <img src="https://placehold.co/40x40" class="rounded-circle me-2" alt="ユーザー">
+                            <img src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3e%3crect width='40' height='40' fill='%23cccccc'/%3e%3ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='10' fill='%23ffffff'%3eUser%3c/text%3e%3c/svg%3e" class="rounded-circle me-2" alt="ユーザー">
                             <div>
                                 <h6 class="fw-bold mb-0">GourmetLover</h6>
                                 <small class="text-muted">2023/12/15 訪問</small>
@@ -153,7 +153,7 @@
 
                     <div class="review-card">
                         <div class="d-flex align-items-center mb-2">
-                            <img src="https://placehold.co/40x40" class="rounded-circle me-2" alt="ユーザー">
+                            <img src="data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3e%3crect width='40' height='40' fill='%23cccccc'/%3e%3ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='10' fill='%23ffffff'%3eUser%3c/text%3e%3c/svg%3e" class="rounded-circle me-2" alt="ユーザー">
                             <div>
                                 <h6 class="fw-bold mb-0">WineExpert</h6>
                                 <small class="text-muted">2023/11/20 訪問</small>

--- a/shop-list.html
+++ b/shop-list.html
@@ -228,7 +228,7 @@
 
                     <div class="col-md-6 col-lg-4">
                          <div class="shop-card">
-                            <div class="food-icon" style="background-image: url('https://images.unsplash.com/photo-1552566626-52f8b828add9?auto=format&fit=crop&w=800&q=80');"></div>
+                            <div class="food-icon" style="background-image: url('https://images.unsplash.com/photo-1559339352-11d035aa65de?auto=format&fit=crop&w=800&q=80');"></div>
                             <div class="p-3">
                                 <span class="category-badge" style="background-color: #d97706;">中華</span>
                                 <h5 class="fw-bold mb-2">龍天門</h5>


### PR DESCRIPTION
# 表示されない画像とプレースホルダーの修正

## 概要
サイト内の一部の画像が正しく表示されていない問題、およびプレースホルダー画像（placehold.co）が外部サービス依存になっている箇所を修正しました。

## 変更点

### 1. 店舗一覧ページ (`shop-list.html`)
- **変更前**: `shop-list.html` 内の「龍天門」の画像URLがリンク切れ（またはアクセス不安定）の状態でした。
- **変更後**: 確実に表示される Unsplash の画像URLに差し替えました。

### 2. 店舗詳細ページ (`shop-detail.html`)
- **変更前**: 口コミセクションのユーザーアイコンに `https://placehold.co/40x40` という外部サービスを使用していました。
- **変更後**: SVGデータURI（インラインSVG）に置き換えました。
  - **理由**: 外部サービスがダウンしたり遅延したりした場合でも、アイコンが即座に確実に表示されるようにするため。また、無駄なHTTPリクエストを削減するため。

### 3. 食べ歩きログ (`eating-log.html`)
- **変更前**: 「鮨 〇〇」の画像がリンク切れ、かつ内容が不適切（ワインの画像）でした。
- **変更後**: 正しい寿司の画像（`shop-list.html`と同一）に差し替えました。

### 4. グルメコラム (`gourmet-guide.html`)
- **変更前**: 「ワインの選び方」記事の画像がリンク切れでした。
- **変更後**: 表示可能なレストラン内観の画像に差し替えました。

## 動作確認手順
1. `shop-list.html` をブラウザで開き、「龍天門」のカード画像が表示されていることを確認する。
2. `shop-detail.html` をブラウザで開き、口コミ（Reviews）セクションのユーザーアイコン（グレーの四角形に"User"の文字）が表示されていることを確認する。
3. `eating-log.html` を開き、寿司店の画像が正しく表示されているか確認する。
4. `gourmet-guide.html` を開き、ワイン記事の画像が表示されているか確認する。

## 備考
- 今回の修正は画像のパスとソースのみの変更であり、レイアウトやCSSへの影響はありません。
